### PR TITLE
Fixes size and alignment computation of bitfields.

### DIFF
--- a/src/C2HS/Gen/Bind.hs
+++ b/src/C2HS/Gen/Bind.hs
@@ -1772,7 +1772,7 @@ instance Ord BitSize where
 -- | add two bit size values
 --
 addBitSize                                 :: BitSize -> BitSize -> BitSize
-addBitSize (BitSize o1 b1) (BitSize o2 b2)  = BitSize (o1 + o2 + overflow) rest
+addBitSize (BitSize o1 b1) (BitSize o2 b2)  = BitSize (o1 + o2 + overflow * CInfo.size CIntPT) rest
   where
     bitsPerBitfield  = CInfo.size CIntPT * 8
     (overflow, rest) = (b1 + b2) `divMod` bitsPerBitfield
@@ -1939,7 +1939,7 @@ alignOffset offset@(BitSize octetOffset bitOffset) align bitfieldAlignment
     offset
   where
     bitsPerBitfield     = CInfo.size CIntPT * 8
-    overflowingBitfield = bitOffset - align >= bitsPerBitfield
+    overflowingBitfield = bitOffset - align > bitsPerBitfield
                                     -- note, `align' is negative
 
 


### PR DESCRIPTION
Tested on windows i386 with haskell-platform 2013.2.0.0 and linux x86_64.

Without this fix, the following struct would show different sizes with c2hs {#sizeof bitfields #} and gcc sizeof(bitfields).

```
typedef struct {
    unsigned int b0  :  31;
    unsigned int b30  :  1;
} bitfields;
```

May affect the issues reported in https://github.com/haskell/c2hs/issues/32 and https://github.com/haskell/c2hs/issues/10.

This patch is based on 0.16.5 rather than HEAD to avoid a supposed regression reported in https://github.com/haskell/c2hs/issues/60. Would merge well with current master though.
