### PR TITLE
Update Bind.hs

### DIFF
--- a/src/C2HS/Gen/Bind.hs
+++ b/src/C2HS/Gen/Bind.hs
@@ -1612,7 +1612,7 @@ extractCompType isResult usePtrAliases cdecl@(CDecl specs' declrs ats)  =
     [(Just declr, _, size)] | isPtrDeclr declr -> ptrType declr
                             | isFunDeclr declr -> funType
                             | otherwise        -> aliasOrSpecType size
-    []                                         -> aliasOrSpecType Nothing
+    _                                          -> aliasOrSpecType Nothing
   where
     -- handle explicit pointer types
     --


### PR DESCRIPTION
Add the case when the first element of the first declrs tuple is Nothing
 into extractCompType's case matching.

I'm not sure if this change is correct, but at least it resolves a
 'c2hs: src/C2HS/Gen/Bind.hs:(1610,8)-(1614,73): Non-exhaustive patterns in case'
 error which I met...
