### PR TITLE
Generate preprocessed file and dumped hsc in specified directory

### DIFF
--- a/src/System/CIO.hs
+++ b/src/System/CIO.hs
@@ -50,7 +50,7 @@ module System.CIO (
             --
             -- `Directory'
             --
-            doesFileExist, removeFile,
+            createDirectoryIfMissing, doesFileExist, removeFile,
             --
             -- `System'
             --
@@ -64,7 +64,8 @@ where
 
 import Prelude (Bool, Char, String, FilePath, (.), ($), Show, return)
 import qualified System.IO as IO
-import qualified System.Directory   as IO (doesFileExist, removeFile)
+import qualified System.Directory   as IO
+                  (createDirectoryIfMissing, doesFileExist, removeFile)
 import qualified System.Environment as IO (getArgs, getProgName)
 import qualified System.Cmd  as IO (system)
 import qualified System.Exit as IO (ExitCode(..), exitWith)
@@ -149,6 +150,9 @@ newline  = putChar '\n'
 
 -- `Directory'
 -- -----------
+
+createDirectoryIfMissing   :: Bool -> FilePath -> PreCST e s ()
+createDirectoryIfMissing p  = liftIO . IO.createDirectoryIfMissing p
 
 doesFileExist :: FilePath -> PreCST e s Bool
 doesFileExist  = liftIO . IO.doesFileExist


### PR DESCRIPTION
c2hs always generates the preprocessed file and dumped hsc in current working directory, if multiple c2hs run at the same time over the same .chs file or .chs files with the same name but in different directories, race happens.

before:

```
Attempting to read file `s/Main.chs'...
...parsing `s/Main'...
...successfully loaded `s/Main'.
Invoking cpp as `cpp -x c t/s/Main.chs.h'...
Attempting to read file `Main.i'...
...parsing `Main.i'...
...name analysis of `Main.i'...
...successfully loaded `Main.i'.
...expanding binding hooks...
...successfully completed.
```

after:

```
c2hs -d trace -t t s/Main.chs
Attempting to read file `s/Main.chs'...
...parsing `s/Main'...
...successfully loaded `s/Main'.
Invoking cpp as `cpp -x c -U__BLOCKS__ t/s/Main.chs.h'...
Attempting to read file `t/s/Main.i'...
...parsing `t/s/Main.i'...
...name analysis of `t/s/Main.i'...
...successfully loaded `t/s/Main.i'.
...expanding binding hooks...
...successfully completed.
```
