### PR TITLE
Better error messages for hook syntax errors

### DIFF
--- a/src/C2HS/CHS.hs
+++ b/src/C2HS/CHS.hs
@@ -876,6 +876,7 @@ parseFrags tokens  = do
     parseFrags0 (CHSTokHook hkpos:
                  CHSTokPointer pos  :toks) = parsePointer hkpos pos
                                              (removeCommentInHook toks)
+    parseFrags0 (CHSTokHook _       :toks) = syntaxError toks
     parseFrags0 toks                       = syntaxError toks
     --
     -- skip to next Haskell or control token

--- a/src/C2HS/CHS/Lexer.hs
+++ b/src/C2HS/CHS/Lexer.hs
@@ -262,6 +262,7 @@ instance Pos CHSToken where
   posOf (CHSTokRBrace  pos  ) = pos
   posOf (CHSTokLParen  pos  ) = pos
   posOf (CHSTokRParen  pos  ) = pos
+  posOf (CHSTokHook    pos  ) = pos
   posOf (CHSTokEndHook pos  ) = pos
   posOf (CHSTokAdd     pos  ) = pos
   posOf (CHSTokAs      pos  ) = pos
@@ -319,6 +320,7 @@ instance Eq CHSToken where
   (CHSTokRBrace   _  ) == (CHSTokRBrace   _  ) = True
   (CHSTokLParen   _  ) == (CHSTokLParen   _  ) = True
   (CHSTokRParen   _  ) == (CHSTokRParen   _  ) = True
+  (CHSTokHook     _  ) == (CHSTokHook     _  ) = True
   (CHSTokEndHook  _  ) == (CHSTokEndHook  _  ) = True
   (CHSTokAdd      _  ) == (CHSTokAdd      _  ) = True
   (CHSTokAs       _  ) == (CHSTokAs       _  ) = True
@@ -377,6 +379,7 @@ instance Show CHSToken where
   showsPrec _ (CHSTokRBrace  _  ) = showString "}"
   showsPrec _ (CHSTokLParen  _  ) = showString "("
   showsPrec _ (CHSTokRParen  _  ) = showString ")"
+  showsPrec _ (CHSTokHook    _  ) = showString "{#"
   showsPrec _ (CHSTokEndHook _  ) = showString "#}"
   showsPrec _ (CHSTokAdd     _  ) = showString "add"
   showsPrec _ (CHSTokAs      _  ) = showString "as"


### PR DESCRIPTION
Sometimes, I accidentally type fake identifiers after a token hook (`{#`). If I were to type, say, `{#notreal#}`, and preprocess it with `c2hs`, this is the error it would give me:

```
c2hs: src/C2HS/CHS/Lexer.hs:(252,3)-(306,35): Non-exhaustive patterns in function posOf
```

Whoops, it looks like there aren't `Show`, `Pos`, or `Eq` instances for `CHSTokHook`. After adding them, this is what the error tells me:

```
src/Pointer.chs:11: (column 1) [ERROR]  >>> Syntax error!
  The phrase `{#' is not allowed here.
```

That's better, but I still don't feel as if this is telling me the root cause of the issue. After adding an additional syntax error case to `parseFrags0`, the error now feels more enlightening:

```
src/Pointer.chs:11: (column 3) [ERROR]  >>> Syntax error!
  The phrase `notreal' is not allowed here.
```
