### PR TITLE
Get ready for AMP and fix a deprecated import

### DIFF
--- a/src/Control/StateBase.hs
+++ b/src/Control/StateBase.hs
@@ -56,6 +56,8 @@ import qualified Control.StateTrans as StateTrans (liftIO)
 import Data.Errors     (ErrorLevel(..), Error)
 import Language.C.Data.Name
 
+import Control.Applicative (Applicative(..))
+import Control.Monad (liftM, ap)
 
 -- state used in the whole compiler
 -- --------------------------------
@@ -80,6 +82,13 @@ data BaseState e = BaseState {
 --
 
 newtype PreCST e s a = CST (STB (BaseState e) s a)
+
+instance Functor (PreCST e s) where
+  fmap = liftM
+
+instance Applicative (PreCST e s) where
+  pure  = return
+  (<*>) = ap
 
 instance Monad (PreCST e s) where
   return = yield

--- a/src/Control/StateTrans.hs
+++ b/src/Control/StateTrans.hs
@@ -73,6 +73,9 @@ module Control.StateTrans (-- the monad and the generic operations
                    throwExc, fatal, catchExc, fatalsHandledBy)
 where
 
+
+import Control.Applicative (Applicative(..))
+import Control.Monad (liftM, ap)
 import Control.Exception (catch)
 import Prelude hiding (catch)
 
@@ -98,6 +101,13 @@ import Prelude hiding (catch)
 --   @Right a@         -- is a successfully delivered result
 --
 newtype STB bs gs a = STB (bs -> gs -> IO (bs, gs, Either (String, String) a))
+
+instance Functor (STB bs gs) where
+  fmap = liftM
+
+instance Applicative (STB bs gs) where
+  pure  = return
+  (<*>) = ap
 
 instance Monad (STB bs gs) where
   return = yield

--- a/src/System/CIO.hs
+++ b/src/System/CIO.hs
@@ -67,8 +67,8 @@ import qualified System.IO as IO
 import qualified System.Directory   as IO
                   (createDirectoryIfMissing, doesFileExist, removeFile)
 import qualified System.Environment as IO (getArgs, getProgName)
-import qualified System.Cmd  as IO (system)
-import qualified System.Exit as IO (ExitCode(..), exitWith)
+import qualified System.Process as IO (system)
+import qualified System.Exit    as IO (ExitCode(..), exitWith)
 
 import Control.StateBase (PreCST, liftIO)
 


### PR DESCRIPTION
As you might be well aware, the Applicative-Monad Proposal is on its second stage, and GHC 7.8 issues a warning if a Monad isn't also an Applicative. Such instances will break in GHC 7.10. So I added those instances where needed, and fixed one deprecated import as well.

A problem that remains is a future name clash:

```
src/Data/DLists.hs:61:1: Warning:
    Local definition of ‘join’ clashes with a future Prelude name - this will become an error in GHC 7.10, under the Applicative-Monad Proposal.
```

We can either rename `join` to `append` (as in the `dlist` package), or even switch to using `dlist`.
