### PR TITLE
Remove extra space from comments

### DIFF
--- a/src/C2HS/CHS.hs
+++ b/src/C2HS/CHS.hs
@@ -641,7 +641,7 @@ showCHSParm (CHSParm oimMarsh hsTyStr twoCVals oomMarsh _ comment)  =
     showHsVerb str = showChar '`' . showString str . showChar '\''
     showComment str = if null str
                       then showString ""
-                      else showString "-- " . showString str . showChar '\n'
+                      else showString "--" . showString str . showChar '\n'
 
 showCHSTrans :: CHSTrans -> ShowS
 showCHSTrans (CHSTrans _2Case chgCase assocs)  =

--- a/src/C2HS/CHS/Lexer.hs
+++ b/src/C2HS/CHS/Lexer.hs
@@ -423,7 +423,7 @@ instance Show CHSToken where
   showsPrec _ (CHSTokCtrl    _ c) = showChar c
   showsPrec _ (CHSTokComment _ s) = showString (if null s
                                                 then ""
-                                                else " -- " ++ s ++ "\n")
+                                                else " --" ++ s ++ "\n")
 
 -- lexer state
 -- -----------

--- a/src/C2HS/Gen/Bind.hs
+++ b/src/C2HS/Gen/Bind.hs
@@ -1022,7 +1022,7 @@ funDef isPure hsLexeme fiLexeme extTy octxt parms parm marsh2 pos hkpos =
       let
         showComment str = if null str
                           then ""
-                          else " -- " ++ str ++ "\n"
+                          else " --" ++ str ++ "\n"
         ctxt   = case octxt of
                    Nothing      -> ""
                    Just ctxtStr -> ctxtStr ++ " => "


### PR DESCRIPTION
The fix for issue #62 (support Haddock comments for function arguments)
added an extra space between the '--' and the comment, resulting in
comments like '-- ^ Foo' turning into '--  ^ Foo'. Haddock does not
parse the second form as a valid function argument description.
