### PR TITLE
Do not swallow newline when parsing comments

### DIFF
--- a/src/C2HS/CHS/Lexer.hs
+++ b/src/C2HS/CHS/Lexer.hs
@@ -679,8 +679,8 @@ bhLexer  =      identOrKW
            >||< hsquot
            >||< whitespace
            >||< endOfHook
-           >||< string "--" +> anyButNL`star` char '\n'   -- comment
-                `lexaction` \cs pos -> Just (CHSTokComment pos (init (drop 2 cs)))
+           >||< string "--" +> anyButNL`star` epsilon  -- comment
+                `lexaction` \cs pos -> Just (CHSTokComment pos (drop 2 cs))
            where
              anyButNL  = alt (anySet \\ ['\n'])
              endOfHook = string "#}"


### PR DESCRIPTION
The lexer processed the trailing newline following a comment as part of
the comment, but did not update the token position to reflect this. This
caused the generated LINE pragmas following function argument comments
to be wrong. This again seemed to cause Haddock some headache, resulting
in misplaced function descriptions
