### PR TITLE
segmentation fault when accesing array inside struct

### DIFF
--- a/tests/bugs/issue-999/Issue999.chs
+++ b/tests/bugs/issue-999/Issue999.chs
@@ -1,0 +1,19 @@
+module Main where
+
+import Foreign
+import Foreign.C
+
+#include "issue999.h"
+
+{#pointer *array_t as MyStruct#}
+
+{#fun get_struct {`Int', `Int', `Int'} -> `MyStruct' return* #}
+
+main :: IO ()
+main = do
+    myStruct <- get_struct 7 42 93
+    p <- {#get array_t->p#} myStruct >>= peekArray 3
+    print p
+    -- The following line produces a segmentation fault
+    a <- {#get array_t->a#} myStruct >>= peekArray 3
+    print a

--- a/tests/bugs/issue-999/issue999.c
+++ b/tests/bugs/issue-999/issue999.c
@@ -1,0 +1,14 @@
+#include "issue999.h"
+
+array_t myStruct;
+
+array_t *get_struct(int n, int m, int o)
+{
+    myStruct.a[0] = n;
+    myStruct.a[1] = m;
+    myStruct.a[2] = o;
+
+    myStruct.p = myStruct.a;
+
+    return &myStruct;
+}

--- a/tests/bugs/issue-999/issue999.h
+++ b/tests/bugs/issue-999/issue999.h
@@ -1,0 +1,8 @@
+#pragma once
+
+typedef struct {
+    int a[3]; /* An array of length 3. */
+    int *p;   /* A pointer to an array. */
+} array_t;
+
+array_t *get_struct(int n, int m, int o);

--- a/tests/test-bugs.hs
+++ b/tests/test-bugs.hs
@@ -55,6 +55,7 @@ tests =
     , testCase "Issue #16" issue16
 --    , testCase "Issue #10" issue10
     , testCase "Issue #7" issue7
+    , testCase "Issue #999" issue999
     ]
   ]
 
@@ -193,6 +194,9 @@ issue7 = c2hsShelly $ do
       run "c2hs" [toTextIgnore "Issue7.chs"]
   code <- lastExitCode
   liftIO $ assertBool "" (code == 0)
+
+issue999 :: Assertion
+issue999 = expect_issue 999 ["[7,42,93]", "[7,42,93]"]
 
 do_issue_build :: Bool -> Int -> String -> [Text] -> Sh ()
 do_issue_build cbuild n ext c2hsargs =


### PR DESCRIPTION
Dear Maintainer,

when I am trying to access an array inside a struct by using {#get#} my program fails with a segmentation fault. 

Doing the following change to the produced .hs file gives me the expected behavior:

``` diff
-    a <- (\ptr -> do {peekByteOff ptr 0 ::IO (Ptr CInt)}) myStruct >>= peekArray 3
+    a <- (\ptr -> do {return (plusPtr ptr 0) ::IO (Ptr CInt)}) myStruct >>= peekArray 3
```

I have attached an test case which can reproduce this issue.

Kind regards,

Kai Harries
