### PR TITLE
Adding (minimal) support for va_list: extend BuiltCO with a Maybe CDecl

### DIFF
--- a/src/C2HS/C/Attrs.hs
+++ b/src/C2HS/C/Attrs.hs
@@ -269,12 +269,13 @@ pshow = renderStyle (Style OneLineMode 80 1.5) . pretty
 data CObj = TypeCO    CDecl             -- typedef declaration
           | ObjCO     CDecl             -- object or function declaration
           | EnumCO    Ident CEnum       -- enumerator
-          | BuiltinCO                   -- builtin object
+          | BuiltinCO (Maybe CDecl)     -- builtin object, with equivalent
+                                        -- C decl if one exists
 instance Show CObj where
   show (TypeCO decl) = "TypeCO { " ++ pshow decl ++ " }"
   show (ObjCO decl) = "ObjCO  { "++ pshow decl ++ " }"
   show (EnumCO ide enum) = "EnumCO "++ show ide ++ " { " ++ pshow enum  ++ " }"
-  show BuiltinCO = "BuiltinCO"
+  show (BuiltinCO _) = "BuiltinCO"
 
 -- two C objects are equal iff they are defined by the same structure
 -- tree node (i.e., the two nodes referenced have the same attribute
@@ -290,7 +291,7 @@ instance Pos CObj where
   posOf (TypeCO    def  ) = posOf def
   posOf (ObjCO     def  ) = posOf def
   posOf (EnumCO    ide _) = posOf ide
-  posOf (BuiltinCO      ) = builtinPos
+  posOf (BuiltinCO _    ) = builtinPos
 
 
 -- C tagged objects including operations

--- a/src/C2HS/C/Builtin.hs
+++ b/src/C2HS/C/Builtin.hs
@@ -33,12 +33,38 @@ module C2HS.C.Builtin (
   builtinTypeNames
 ) where
 
-import Language.C.Data.Ident (Ident, builtinIdent)
+-- Language.C / compiler toolkit
+import Language.C.Data.Position
+import Language.C.Data.Ident
+import Language.C.Syntax
+import Language.C.Data
 
 import C2HS.C.Attrs (CObj(BuiltinCO))
-
 
 -- | predefined type names
 --
 builtinTypeNames :: [(Ident, CObj)]
-builtinTypeNames  = [(builtinIdent "__builtin_va_list", BuiltinCO)]
+builtinTypeNames  =
+    [(va_list_ide, BuiltinCO $ Just ptrVoidDecl)]
+    where
+        va_list_ide :: Ident
+        va_list_ide = builtinIdent "__builtin_va_list"
+
+        ptrVoidDecl :: CDecl
+        ptrVoidDecl =
+            CDecl [ CStorageSpec (CTypedef builtin)
+                  , CTypeSpec (CVoidType builtin)
+                  ]
+                  [( Just $ CDeclr (Just va_list_ide)
+                                   [CPtrDeclr [] builtin]
+                                   Nothing
+                                   []
+                                   builtin
+                   , Nothing
+                   , Nothing
+                   )]
+                  builtin
+
+        builtin :: NodeInfo
+        builtin = mkNodeInfoOnlyPos builtinPos
+

--- a/src/C2HS/Gen/Bind.hs
+++ b/src/C2HS/Gen/Bind.hs
@@ -1366,7 +1366,7 @@ addDftMarshaller pos parms parm extTy varExTys = do
     --
     addDftVoid marsh@(Just (_, kind)) = return (marsh, kind == CHSIOArg)
     addDftVoid Nothing = do
-      return (Just (Left (internalIdent "void"), CHSVoidArg), False)
+      return (Just (Left voidIde, CHSVoidArg), False)
 
 -- | compute from an access path, the declarator finally accessed and the index
 -- path required for the access


### PR DESCRIPTION
HI chaps;

I'm prepping for open release some Java interop libraries I developed for FP Complete back in the winter of '13.

The low-level library is called jni-ffi, and is a modern, C2HS-based API to the JNI. It's essentially Erik and Sigbjorn's work redone with modern tools.

In order to get c2hs to accept jni.h, I had to add support for va_list. The tool gives them a void* type, which is sufficient for my purposes. A more thorough approach might be warranted to properly support this kind of meta-decl.

Cheers,

Andy
