### PR TITLE
print position info for more errors (replace interr with errorAtPos)

### DIFF
--- a/src/C2HS/Gen/Bind.hs
+++ b/src/C2HS/Gen/Bind.hs
@@ -2548,12 +2548,12 @@ applyBin _    COrOp  (IntResult   x)
                      (IntResult   y) = return $ IntResult (x .|. y)
 applyBin _    CAndOp (IntResult   x)
                      (IntResult   y) = return $ IntResult (x .&. y)
-applyBin _    _      (IntResult   _)
+applyBin pos  _      (IntResult   _)
                      (IntResult   _) =
-  todo "GenBind.applyBin: Not yet implemented operator in constant expression."
-applyBin _    _      (FloatResult _)
+  todo $ "GenBind.applyBin: Not yet implemented operator in constant expression. " ++ show pos
+applyBin pos  _      (FloatResult _)
                      (FloatResult _) =
-  todo "GenBind.applyBin: Not yet implemented operator in constant expression."
+  todo $ "GenBind.applyBin: Not yet implemented operator in constant expression. " ++ show pos
 applyBin pos    _      _ _             =
   errorAtPos pos ["GenBind.applyBinOp: Illegal combination!"]
 
@@ -2573,8 +2573,8 @@ applyUnary cpos CIndOp     _               =
 applyUnary _    CPlusOp    arg             = return arg
 applyUnary _    CMinOp     (IntResult   x) = return (IntResult (-x))
 applyUnary _    CMinOp     (FloatResult x) = return (FloatResult (-x))
-applyUnary _    CCompOp    _               =
-  todo "GenBind.applyUnary: ~ not yet implemented."
+applyUnary pos  CCompOp    _               =
+  todo $ "GenBind.applyUnary: ~ not yet implemented. " ++ show pos
 applyUnary _    CNegOp     (IntResult   x) =
   let r = toInteger . fromEnum $ (x == 0)
   in return (IntResult r)


### PR DESCRIPTION
Some errors are very hard to debug because they don't tell where in the C source the error occurred.

For example, instead of printing:
```
c2hs: INTERNAL COMPILER ERROR:
  GenBind.sizeAlignOf: array of undeclared size.
```
We now print:
```
c2hs: path/to/file.h:100: (column 118) [ERROR]  >>> GenBind.sizeAlignOf: array of undeclared size.
```