### PR TITLE
Hack to avoid Apple's block syntax.

### DIFF
--- a/c2hs.cabal
+++ b/c2hs.cabal
@@ -1,5 +1,5 @@
 Name:           c2hs
-Version:        0.25.2
+Version:        0.25.3
 License:        GPL-2
 License-File:   COPYING
 Copyright:      Copyright (c) 1999-2007 Manuel M T Chakravarty
@@ -100,6 +100,7 @@ flag base3
 
 Executable c2hs
     Build-Depends:  base >= 2 && < 5,
+                    bytestring,
                     language-c >= 0.4.7 && < 0.5,
                     filepath,
                     dlist


### PR DESCRIPTION
This performs a textual substitution of "(^" with "(*" when initially
reading a header file before passing it to the language-c parser. This
treats any block type definitions as function pointer type
definitions. While this is not right, it is unlikely that correct
treatment of this functionality is depended upon by any c2hs clients.

Without something to address this, c2hs can no longer be used to work
with Apple's OpenCL framework.

Fixes #138