### PR TITLE
Add InterruptibleFFI support

### DIFF
--- a/doc/c2hs.xml
+++ b/doc/c2hs.xml
@@ -447,17 +447,18 @@ Create a haskell datatype <replaceable>hsid</replaceable>, with nullary construc
     <title>Call Hooks</title>
     <para>
 <programlisting>
-{#call [pure] [unsafe] <replaceable>cid</replaceable> [as (<replaceable>hsid</replaceable> | ^)]#}
+{#call [pure] [unsafe] [interruptible] <replaceable>cid</replaceable> [as (<replaceable>hsid</replaceable> | ^)]#}
 </programlisting>
 
     A call hook rewrites to a call to the C function
     <replaceable>cid</replaceable> and also ensures that the appropriate foreign
     import declaration is generated.  The tags <literal>pure</literal> and
     <literal>unsafe</literal> specify that the external function is purely
-    functional and cannot re-enter the Haskell runtime, respectively.  If
-    <replaceable>hsid</replaceable> is present, it is used as the identifier for
-    the foreign declaration, which otherwise defaults to the
-    <replaceable>cid</replaceable>.  When instead of
+    functional and cannot re-enter the Haskell runtime, respectively.  The
+    <literal>interruptible</literal> flag is intended to be used in conjunction
+    with the InterruptibleFFI extension. If <replaceable>hsid</replaceable> is
+    present, it is used as the identifier for the foreign declaration, which
+    otherwise defaults to the <replaceable>cid</replaceable>.  When instead of
     <replaceable>hsid</replaceable>, the symbol <literal>^</literal> is given,
     the <replaceable>cid</replaceable> after conversion from C's underscore
     notation to a capitalised identifier is used.
@@ -477,7 +478,7 @@ sin  = {#call pure sin as "_sin"#}
     <title>Function Hooks</title>
     <para>
 <programlisting>
-{#fun  [pure] [unsafe] <replaceable>cid</replaceable> [as (<replaceable>hsid</replaceable> | ^)]
+{#fun  [pure] [unsafe] [interruptible] <replaceable>cid</replaceable> [as (<replaceable>hsid</replaceable> | ^)]
 [<replaceable>ctxt</replaceable> =>] { <replaceable>parm1</replaceable> , ... , <replaceable>parmn</replaceable> } -> <replaceable>parm</replaceable>
 </programlisting>
 
@@ -1004,8 +1005,8 @@ inner    -> `import' ['qualified'] ident
           | `type' ident
           | `sizeof' ident
           | `enum' idalias trans [`with' prefix] [deriving]
-          | `call' [`pure'] [`unsafe'] idalias
-          | `fun' [`pure'] [`unsafe'] idalias parms
+          | `call' [`pure'] [`unsafe'] [`interruptible'] idalias
+          | `fun' [`pure'] [`unsafe'] [`interruptible'] idalias parms
           | `get' apath
           | `set' apath
           | `pointer' ['*'] idalias ptrkind

--- a/src/C2HS/CHS/Lexer.hs
+++ b/src/C2HS/CHS/Lexer.hs
@@ -90,7 +90,7 @@
 --      cidenttail  -> digit (letter | digit)*
 --      reservedid  -> `add' | `as' | `call' | `class' | `context' | `deriving'
 --                   | `enum' | `foreign' | `fun' | `get' | `lib'
---                   | `downcaseFirstLetter' | `finalizer'
+--                   | `downcaseFirstLetter' | `finalizer' | `interruptible'
 --                   | `newtype' | `nocode' | `pointer' | `prefix' | `pure'
 --                   | `set' | `sizeof' | `stable' | `struct' | `type'
 --                   | `underscoreToCase' | `upcaseFirstLetter' | `unsafe' |
@@ -230,6 +230,7 @@ data CHSToken = CHSTokArrow   Position          -- `->'
               | CHSTokFun     Position          -- `fun'
               | CHSTokGet     Position          -- `get'
               | CHSTokImport  Position          -- `import'
+              | CHSTokIntr    Position          -- `interruptible'
               | CHSTokLib     Position          -- `lib'
               | CHSTokNewtype Position          -- `newtype'
               | CHSTokNocode  Position          -- `nocode'
@@ -446,6 +447,7 @@ instance Show CHSToken where
   showsPrec _ (CHSTokFun     _  ) = showString "fun"
   showsPrec _ (CHSTokGet     _  ) = showString "get"
   showsPrec _ (CHSTokImport  _  ) = showString "import"
+  showsPrec _ (CHSTokIntr    _  ) = showString "interruptible"
   showsPrec _ (CHSTokLib     _  ) = showString "lib"
   showsPrec _ (CHSTokNewtype _  ) = showString "newtype"
   showsPrec _ (CHSTokNocode  _  ) = showString "nocode"
@@ -821,6 +823,7 @@ identOrKW  =
     idkwtok pos "fun"              _    = CHSTokFun     pos
     idkwtok pos "get"              _    = CHSTokGet     pos
     idkwtok pos "import"           _    = CHSTokImport  pos
+    idkwtok pos "interruptible"    _    = CHSTokIntr    pos
     idkwtok pos "lib"              _    = CHSTokLib     pos
     idkwtok pos "newtype"          _    = CHSTokNewtype pos
     idkwtok pos "nocode"           _    = CHSTokNocode  pos
@@ -868,6 +871,7 @@ keywordToIdent tok =
     CHSTokFun     pos -> mkid pos "fun"
     CHSTokGet     pos -> mkid pos "get"
     CHSTokImport  pos -> mkid pos "import"
+    CHSTokIntr    pos -> mkid pos "interruptible"
     CHSTokLib     pos -> mkid pos "lib"
     CHSTokNewtype pos -> mkid pos "newtype"
     CHSTokNocode  pos -> mkid pos "nocode"

--- a/src/C2HS/Gen/Header.hs
+++ b/src/C2HS/Gen/Header.hs
@@ -219,7 +219,7 @@ ghFrag (_frag@(CHSHook (CHSConst cident pos) hkpos) : frags) =
             Nothing)]
           undefNode
 
-ghFrag (frag@(CHSHook (CHSFun _ _ True varTypes
+ghFrag (frag@(CHSHook (CHSFun _ _ _ True varTypes
                        (CHSRoot _ ide) oalias _ _ _ _) _) : frags) = do
   let ideLexeme = identToString ide
       hsLexeme  = ideLexeme `maybe` identToString $ oalias

--- a/src/C2HS/Gen/Monad.hs
+++ b/src/C2HS/Gen/Monad.hs
@@ -376,12 +376,13 @@ delayCode hook str  =
     where
       newEntry = (hook, (CHSVerb ("\n" ++ str) (posOf hook)))
       --
-      delay hook'@(CHSCall isFun isUns ide _oalias _) frags' =
+      delay hook'@(CHSCall isFun isIntr isUns ide _oalias _) frags' =
         case find (\(hook'', _) -> hook'' == hook') frags' of
-          Just (CHSCall isFun' isUns' ide' _ _, _)
-            |    isFun == isFun'
-              && isUns == isUns'
-              && ide   == ide'   -> return frags'
+          Just (CHSCall isFun' isIntr' isUns' ide' _ _, _)
+            |    isFun  == isFun'
+              && isIntr == isIntr'
+              && isUns  == isUns'
+              && ide    == ide'   -> return frags'
             | otherwise          -> err (posOf ide) (posOf ide')
           Nothing                -> return $ frags' ++ [newEntry]
       delay hook'@(CHSPointer _ _ _ _ _ _ _ _) frags' =


### PR DESCRIPTION
This patch adds [InterruptibleFFI](https://downloads.haskell.org/~ghc/master/users-guide/ffi-chap.html#interruptible-foreign-calls) support.