### PR TITLE
Do not crash with 'c2hs: No match in record selector posRow'

### DIFF
--- a/src/C2HS/Gen/Bind.hs
+++ b/src/C2HS/Gen/Bind.hs
@@ -521,7 +521,9 @@ addImports fs imps = before ++ impfrags ++ after
               else doSplit 0 mln True (f:acc) fs'
           | otherwise = if null (dropWhile isSpace s) || isJust mln
                         then doSplit 0 mln wh (f:acc) fs'
-                        else doSplit 0 (Just $ posRow pos) wh (f:acc) fs'
+                        else doSplit 0 mln' wh (f:acc) fs'
+                          where mln' | isSourcePos pos = Just $ posRow pos
+                                     | otherwise = Nothing
         doSplit cdep mln wh acc (f@(CHSVerb s _) : fs')
           | s == "-}" = doSplit (cdep-1) mln wh (f:acc) fs'
           | s == "{-" = doSplit (cdep+1) mln wh (f:acc) fs'


### PR DESCRIPTION
I had this crash when trying to generate Haskell code for a simple enum.

The posRow selector only works on Position data, and apparently I got something else. As it had a Maybe wrapped around it, I simply allow it to become Nothing to avoid the crash. I am not sure how it blends with the code there, but the generated output looks fine.

Håkan