### PR TITLE
tests: fix missing return statement (issue-128 test)

### DIFF
--- a/tests/bugs/issue-128/issue128.c
+++ b/tests/bugs/issue-128/issue128.c
@@ -20,6 +20,7 @@ tststruct *make_tststruct(int ain)
   tststruct *p = (tststruct *)malloc(sizeof(tststruct));
   p->a = ain;
   p->b = false;
+  return p;
 }
 
 void free_tststruct(tststruct *s)


### PR DESCRIPTION
This leads to a segfault of the test on some platforms.