### PR TITLE
Add MonadFail instance so it compiles with GHC 8.6.1

### DIFF
--- a/c2hs.cabal
+++ b/c2hs.cabal
@@ -122,6 +122,9 @@ Executable c2hs
     else
         Build-Depends: base < 3
 
+    if !impl(ghc >= 8.0)
+        Build-Depends: fail
+
     hs-source-dirs: src
     main-is:        Main.hs
     other-modules:

--- a/src/Control/StateBase.hs
+++ b/src/Control/StateBase.hs
@@ -58,6 +58,7 @@ import Language.C.Data.Name
 
 import Control.Applicative (Applicative(..))
 import Control.Monad (liftM, ap)
+import Control.Monad.Fail (MonadFail (..))
 
 -- state used in the whole compiler
 -- --------------------------------
@@ -82,6 +83,9 @@ data BaseState e = BaseState {
 --
 
 newtype PreCST e s a = CST (STB (BaseState e) s a)
+
+instance MonadFail (PreCST a b) where
+    fail = error
 
 instance Functor (PreCST e s) where
   fmap = liftM


### PR DESCRIPTION
There's probably a better solution than this, but this will at least get it compiling with GHC 8.6.1