### PR TITLE
Never pass empty arguments to cpp.

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -577,8 +577,13 @@ process headerFiles bndFile  =
         versionOpt = [ "-DC2HS_VERSION_MAJOR=" ++ versMajor
                      , "-DC2HS_VERSION_MINOR=" ++ versMinor
                      , "-DC2HS_VERSION_REV=" ++ versRev ]
-        args = cppOpts ++ nonGNUOpts ++ ["-U__BLOCKS__"] ++
-               versionOpt ++ [newHeaderFile]
+        args = filter (not . null) $
+            concat [ cppOpts
+                   , nonGNUOpts
+                   , ["-U__BLOCKS__"]
+                   , versionOpt
+                   , [newHeaderFile]
+                   ]
     tracePreproc (unwords (cpp:args))
     exitCode <- CIO.liftIO $ do
       preprocHnd <- openFile preprocFile WriteMode


### PR DESCRIPTION
If the args list contains any empty strings, these will be emitted as empty spaces in the argument list. `runProcess` will pass these to the cpp executable as real empty string arguments, and some cpp implementations don't handle this well. For example, an implementation I'm stuck using somehow treats this empty argument as the input file name and fails when it's not found. Filtering out null strings from the argument list fixes this.