### PR TITLE
Support GCC extension that allows unnamed struct and union members per C11.

### DIFF
--- a/c2hs.cabal
+++ b/c2hs.cabal
@@ -103,6 +103,7 @@ Extra-Source-Files:
   tests/bugs/issue-155/*.chs tests/bugs/issue-155/*.h
   tests/bugs/issue-180/*.chs tests/bugs/issue-180/*.h
   tests/bugs/issue-192/*.chs tests/bugs/issue-192/*.h
+  tests/bugs/issue-230/*.chs tests/bugs/issue-230/*.h tests/bugs/issue-230/*.c
 
 source-repository head
   type:         git
@@ -151,6 +152,7 @@ Executable c2hs
       Data.Attributes
       Data.Errors
       Data.NameSpaces
+      Paths_c2hs
       System.CIO
       Text.Lexers
 

--- a/src/C2HS/C/Trav.hs
+++ b/src/C2HS/C/Trav.hs
@@ -509,8 +509,11 @@ structMembers (CStruct tag _ members _ _) = (concat . map expandDecl $ maybe [] 
 
 -- | expand declarators declaring more than one identifier into multiple
 -- declarators, eg, `int x, y;' becomes `int x; int y;'
+-- For case of a declarator that declares no identifier, preserve the no-identifier decl.
 --
 expandDecl                        :: CDecl -> [CDecl]
+expandDecl decl@(CDecl _ [] _)     =
+  [decl] -- no name member stays as member without a name.
 expandDecl (CDecl specs decls at)  =
   map (\decl -> CDecl specs [decl] at) decls
 

--- a/tests/bugs/issue-230/Issue230.chs
+++ b/tests/bugs/issue-230/Issue230.chs
@@ -1,0 +1,38 @@
+module Main where
+
+#include "issue230.h"
+
+import Control.Monad (liftM)
+import Foreign.C
+
+cIntConv :: CInt-> Int
+cIntConv = fromIntegral
+
+cDblConv :: CDouble -> Double
+cDblConv = realToFrac
+
+main :: IO ()
+main  = do
+  test1 <- {#call make_test1#}
+  val1A <- liftM cIntConv $ {#get test1->a#} test1
+  val1B <- liftM cIntConv $ {#get test1->b#} test1
+  val1C <- liftM cIntConv $ {#get test1->c#} test1
+  val1D <- liftM cDblConv $ {#get test1->d#} test1
+
+  test2 <- {#call make_test2#}
+  val2A <- liftM cIntConv $ {#get test2->a#} test2
+  val2B <- liftM cIntConv $ {#get test2->b#} test2
+  val2C <- liftM cIntConv $ {#get test2->c#} test2
+  val2D <- liftM cDblConv $ {#get test2->d#} test2
+
+  putStrLn (show val1A)
+  putStrLn (show val1B)
+  putStrLn (show val1C)
+  putStrLn (show val1D)
+  putStrLn (show val2A)
+  putStrLn (show val2B)
+  putStrLn (show $ val2C /= 7)
+  putStrLn (show val2D)
+
+  return ()
+

--- a/tests/bugs/issue-230/issue230.c
+++ b/tests/bugs/issue-230/issue230.c
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+
+#include "issue230.h"
+
+struct test1 *make_test1(void)
+{
+  struct test1 *t = malloc(sizeof(struct test1));
+  t->a = 1;
+  t->b = 2;
+  t->c = 3;
+  t->d = 4.0;
+  return t;
+}
+
+struct test2 *make_test2(void)
+{
+  struct test2 *t = malloc(sizeof(struct test2));
+  t->a = 5;
+  t->b = 6;
+  t->c = 7;
+  t->d = 8.0;
+  return t;
+}

--- a/tests/bugs/issue-230/issue230.h
+++ b/tests/bugs/issue-230/issue230.h
@@ -1,0 +1,20 @@
+struct test1 {
+  int a;
+  struct {
+    int c;
+    double d;
+  };
+  int b;
+};
+
+struct test2 {
+  int a;
+  union {
+    int c;
+    double d;
+  };
+  int b;
+};
+
+struct test1* make_test1(void);
+struct test2* make_test2(void);

--- a/tests/test-bugs.hs
+++ b/tests/test-bugs.hs
@@ -94,6 +94,7 @@ tests =
     , testCase "Issue #155" issue155
     , testCase "Issue #180" issue180
     , testCase "Issue #192" issue192
+    , testCase "Issue #230" issue230
     ] ++
     -- Some tests that won't work on Windows.
     if os /= "cygwin32" && os /= "mingw32"
@@ -113,6 +114,9 @@ call_capital = c2hsShelly $ chdir "tests/bugs/call_capital" $ do
   res <- absPath "./Capital" >>= cmd
   let expected = ["upper C();", "lower c();", "upper C();"]
   liftIO $ assertBool "" (T.lines res == expected)
+
+issue230 :: Assertion
+issue230 = expect_issue 230 ["1", "2", "3", "4.0", "5", "6", "True", "8.0"]
 
 issue192 :: Assertion
 issue192 = hs_only_build_issue 192


### PR DESCRIPTION
Contribute code the supports unnamed struct and union fields within structs and unions, which is in the C11 spec. The names in the nested struct can be used without qualification in the CHS bindings.

Also added regression tests (issue 230) for unnamed struct/union membes.