### PR TITLE
Add support for == in macros

### DIFF
--- a/src/C2HS/Gen/Bind.hs
+++ b/src/C2HS/Gen/Bind.hs
@@ -2771,6 +2771,10 @@ applyBin _    COrOp  (IntResult   x)
                      (IntResult   y) = return $ IntResult (x .|. y)
 applyBin _    CAndOp (IntResult   x)
                      (IntResult   y) = return $ IntResult (x .&. y)
+applyBin _    CEqOp  (IntResult   x)
+                     (IntResult   y) = return $ IntResult (if x == y then 1 else 0)
+applyBin _    CNeqOp (IntResult   x)
+                     (IntResult   y) = return $ IntResult (if x /= y then 1 else 0)
 applyBin pos  _      (IntResult   _)
                      (IntResult   _) =
   todo $ "GenBind.applyBin: Not yet implemented operator in constant expression. " ++ show pos


### PR DESCRIPTION
This fixes a past infelicity that meant that 

```
#define LZ4_STREAMSIZE_U64 ((1 << (LZ4_MEMORY_USAGE-3)) + 4 + ((sizeof(void*)==16) ? 4 : 0) /*AS-400*/ )
#define LZ4_STREAMSIZE     (LZ4_STREAMSIZE_U64 * sizeof(unsigned long long))
```

caused problems

Thanks!