### PR TITLE
Fix test compilation #245

### DIFF
--- a/tests/test-bugs.hs
+++ b/tests/test-bugs.hs
@@ -463,17 +463,17 @@ do_issue_build strict cbuild n suff ext c2hsargs =
     run "c2hs" $ c2hsargs ++ [toTextIgnore $ uc <.> "chs"]
     code <- lastExitCode
     when (code == 0) $ do
-      when cbuild $ cmd cc "-c" "-o" (lcc <.> "o") (lc <.> "c")
+      when cbuild $ cmd cc "-c" "-o" (T.pack $ lcc <.> "o") (T.pack $ lc <.> "c")
       code <- lastExitCode
       when (code == 0) $ case (strict, cbuild) of
         (True, True) ->
-          cmd "ghc" "-Wall" "-Werror" "--make" (lcc <.> "o") (uc <.> "hs")
+          cmd "ghc" "-Wall" "-Werror" "--make" (T.pack $ lcc <.> "o") (T.pack $ uc <.> "hs")
         (False, True) ->
-          cmd "ghc" "--make" (lcc <.> "o") (uc <.> "hs")
+          cmd "ghc" "--make" (T.pack $ lcc <.> "o") (T.pack $ uc <.> "hs")
         (True, False) ->
-          cmd "ghc" "-Wall" "-Werror" "--make" (uc <.> "hs")
+          cmd "ghc" "-Wall" "-Werror" "--make" (T.pack $ uc <.> "hs")
         (False, False) ->
-          cmd "ghc" "--make" (uc <.> "hs")
+          cmd "ghc" "--make" (T.pack $ uc <.> "hs")
 
 expect_issue :: Int -> [Text] -> Assertion
 expect_issue n expected = expect_issue_with True True n "" [] expected


### PR DESCRIPTION
The project builds fine, why should we report the status as failing due to some test compilation failure?

As stated in the issue, Shelly 1.9 removes `String` supports and uses `Text` for arguments to `cmd`. So I just `T.pack` them all and deliver this pull request. It builds just find on my machine.