### PR TITLE
Modify some comments that steal haddock syntax

### DIFF
--- a/src/C2HS/C/Names.hs
+++ b/src/C2HS/C/Names.hs
@@ -28,7 +28,7 @@
 --
 --- TODO ----------------------------------------------------------------------
 --
--- * `defObjOrErr': currently, repeated declarations are completely ignored;
+--  * `defObjOrErr': currently, repeated declarations are completely ignored;
 --   eventually, the consistency of the declarations should be checked
 --
 

--- a/src/C2HS/C/Trav.hs
+++ b/src/C2HS/C/Trav.hs
@@ -54,7 +54,7 @@
 --
 --- TODO ----------------------------------------------------------------------
 --
--- * `extractStruct' doesn't account for forward declarations that have no
+--  * `extractStruct' doesn't account for forward declarations that have no
 --   full declaration yet; if `extractStruct' is called on such a declaration,
 --   we have a user error, but currently an internal error is raised
 --

--- a/src/C2HS/Gen/Bind.hs
+++ b/src/C2HS/Gen/Bind.hs
@@ -1500,7 +1500,7 @@ accessPath (CHSRoot _ ide) =                            -- t
   do
     decl <- findAndChaseDecl ide False True
     return (ide `simplifyDecl` decl, [BitSize 0 0])
-accessPath (CHSDeref (CHSRoot _ ide) _) =               -- *t
+accessPath (CHSDeref (CHSRoot _ ide) _) =               --  *t
   do
     decl <- findAndChaseDecl ide True True
     return (ide `simplifyDecl` decl, [BitSize 0 0])
@@ -1529,7 +1529,7 @@ accessPath (CHSRef path ide) =                          -- a.m
       case declr of
         (Just (CDeclr _ [] _ _ _), _, _) -> return ()
         _                                -> structExpectedErr ide'
-accessPath (CHSDeref path _pos) =                        -- *a
+accessPath (CHSDeref path _pos) =                        --  *a
   do
     (decl, offsets) <- accessPath path
     decl' <- derefOrErr decl
@@ -3142,7 +3142,7 @@ cCompiler = unsafePerformIO $ do
           let mungedCc = mungePath topDir cc
           writeIORef cCompilerRef $ Just mungedCc
           return mungedCc
-        _ -> error "Failed to determine C compiler from 'ghc --info'!" 
+        _ -> error "Failed to determine C compiler from 'ghc --info'!"
 
   where
     -- adapted from ghc/compiler/main/Packages.hs

--- a/src/C2HS/Gen/Header.hs
+++ b/src/C2HS/Gen/Header.hs
@@ -39,7 +39,7 @@
 --
 --- TODO ----------------------------------------------------------------------
 --
--- * Ideally, `ghFrag[s]' should be tail recursive
+--  * Ideally, `ghFrag[s]' should be tail recursive
 
 module C2HS.Gen.Header (
   genHeader


### PR DESCRIPTION
Some comments unfortunately began with `*`. In most cases, this was being used for bullet lists, where adding an extra space is more consistent with the rest of the comment block anyway.

Fixes #253, fixes #229.