### PR TITLE
Lifts upper bound on language-c

### DIFF
--- a/c2hs.cabal
+++ b/c2hs.cabal
@@ -114,7 +114,7 @@ flag base3
 Executable c2hs
     Build-Depends:  base >= 2 && < 5,
                     bytestring,
-                    language-c >= 0.7.1 && < 0.9,
+                    language-c >= 0.7.1 && < 0.10,
                     filepath,
                     dlist
 


### PR DESCRIPTION
Closes https://github.com/commercialhaskell/stackage/issues/5633.

I've tested this out locally and the test suite seems to be failing with the following error:
```
TST 3: testing
  Issue #102: [Failed]
ERROR:
Ran commands:
cd /Users/jkachmar/src/c2hs/tests/bugs/issue-102
rm -f /Users/jkachmar/src/c2hs/tests/bugs/issue-102/Issue102.hs
rm -f /Users/jkachmar/src/c2hs/tests/bugs/issue-102/Issue102.chs.h
rm -f /Users/jkachmar/src/c2hs/tests/bugs/issue-102/Issue102.chi
rm -f /Users/jkachmar/src/c2hs/tests/bugs/issue-102/issue102_c.o
rm -f /Users/jkachmar/src/c2hs/tests/bugs/issue-102/Issue102
c2hs Issue102.chs
which c2hs
ghc -Wall -Werror --make Issue102.hs
which ghc
/Users/jkachmar/src/c2hs/tests/bugs/issue-102/./Issue102
which /Users/jkachmar/src/c2hs/tests/bugs/issue-102/./Issue102

Exception: error running: /Users/jkachmar/src/c2hs/tests/bugs/issue-102/./Issue102
exit status: 1
stderr: Issue102: FCntlLockState.toEnum: Cannot match 0
CallStack (from HasCallStack):
  error, called at Issue102.chs:54:22 in main:Main


         Test Cases   Total
 Passed  65           65
 Failed  1            1
 Total   66           66
Test suite test-bugs: FAIL
```
...I'll try to debug whatever is going on to the best of my knowledge, so consider this PR a WIP for the time being.