### PR TITLE
fix typos

### DIFF
--- a/ChangeLog.old
+++ b/ChangeLog.old
@@ -472,7 +472,7 @@ Fri Nov 25 10:54:56 EST 2005  Jelmer Vernooij <jelmer@samba.org>
 2002-01-15  Manuel M T Chakravarty  <chak@cse.unsw.edu.au>
 
 	* gen/GenBind.hs (mergeMaps): now, the read map overrides any
-	entires for shared keys in the map that is already in the monad;
+	entries for shared keys in the map that is already in the monad;
 	this is so that, if multiple import hooks add entries for shared
 	keys, the textually latest prevails; any local entries are entered
 	after all import hooks anyway

--- a/TODO.CTKlight
+++ b/TODO.CTKlight
@@ -38,7 +38,7 @@ Middle Term:
     monad.
   - GHC's system => when attributes of an identifier are updated, the
     "new" identifiers have to substituted into all expression that contain
-    usage occurences.
+    usage occurrences.
 
 * Graph processing support: Does it need to be a new mechanism or can we
   realise it via Attrs (what kind of generic functions could we provide).  One

--- a/examples/libghttpHS/Ghttp.chs
+++ b/examples/libghttpHS/Ghttp.chs
@@ -305,7 +305,7 @@ setProxyAuthinfo (Request reqa) user pass =
   `ifNegRaise_` illegalRequest
 
 
--- auxilliary marshalling function
+-- auxiliary marshalling function
 -- -------------------------------
 
 -- marshal the elements of a `ghttp_current_status' struct to Haskell land

--- a/src/C2HS/C.hs
+++ b/src/C2HS/C.hs
@@ -97,7 +97,7 @@ parseHeader is pos =
                                        return (CTranslUnit [] undefNode)
       Right (ct,ns') -> setNameSupply ns' >> return ct
 
--- | @bsReplace old new haystack@ replaces occurences of @old@ with
+-- | @bsReplace old new haystack@ replaces occurrences of @old@ with
 -- @new@ in the @haystack@.
 bsReplace :: BS.ByteString -> BS.ByteString -> BS.ByteString -> BS.ByteString
 bsReplace old new = go id

--- a/src/C2HS/C/Attrs.hs
+++ b/src/C2HS/C/Attrs.hs
@@ -27,20 +27,20 @@
 --
 --  * The final state of the names spaces are preserved in the attributed
 --    structure tree.  This allows further fast lookups for globally defined
---    identifiers after the name anaysis is over.
+--    identifiers after the name analysis is over.
 --
 --  * In addition to the name spaces, the attribute structure tree contains
 --    a ident-definition table, which for attribute handles of identifiers
 --    refers to the identifiers definition.  These are only used in usage
---    occurences, except for one exception: The tag identifiers in forward
+--    occurrences, except for one exception: The tag identifiers in forward
 --    definitions of structures or enums get a reference to the corresponding
 --    full definition - see `CTrav' for full details.
 --
 --  * We maintain a shadow definition table, it can be populated with aliases
 --    to other objects and maps identifiers to identifiers.  It is populated by
---    using the `applyPrefix' function.  When looksup performed via the shadow
---    variant of a lookup function, shadow aliases are also considered, but
---    they are used only if no normal entry for the identifiers is present.
+--    using the `applyPrefix' function.  When lookups are performed via the
+--    shadow variant of a lookup function, shadow aliases are also considered,
+--    but they are used only if no normal entry for the identifiers is present.
 --
 --  * Only ranges delimited by a block open a new range for tags (see
 --    `enterNewObjRangeC' and `leaveObjRangeC').
@@ -85,7 +85,7 @@ import Data.NameSpaces (NameSpace, nameSpace, enterNewRange, leaveRange, defLoca
 -- attributed C structure tree
 -- ---------------------------
 
--- | attributes relevant to the outside world gathjered from a C unit
+-- | attributes relevant to the outside world gathered from a C unit
 --
 data AttrC = AttrC {
                 defObjsAC :: CObjNS,            -- defined objects
@@ -94,7 +94,7 @@ data AttrC = AttrC {
                 defsAC    :: CDefTable          -- ident-def associations
               } deriving (Show)
 
--- | empty headder attribute set
+-- | empty header attribute set
 --
 emptyAttrC :: AttrC
 emptyAttrC  = AttrC {
@@ -370,7 +370,7 @@ instance Pos CDef where
 -- object tables (internal use only)
 -- ---------------------------------
 
--- | the object name spavce
+-- | the object name space
 --
 type CObjNS = NameSpace CObj
 

--- a/src/C2HS/C/Names.hs
+++ b/src/C2HS/C/Names.hs
@@ -63,7 +63,7 @@ nameAnalysis headder  = do
                           return ac'
 
 
--- name analyis traversal
+-- name analysis traversal
 -- ----------------------
 
 -- | traverse a complete header file

--- a/src/C2HS/C/Trav.hs
+++ b/src/C2HS/C/Trav.hs
@@ -233,7 +233,7 @@ findObjShadow ide  = readAttrCCT $ \ac -> lookupDefObjCShadow ac ide
 --   object association added; otherwise, if a definition of the same name was
 --   already present, it is returned (see DOCU section)
 --
--- * it is checked that the first occurence of an enumeration tag is
+-- * it is checked that the first occurrence of an enumeration tag is
 --   accompanied by a full definition of the enumeration
 --
 defTag         :: Ident -> CTag -> CT s (Maybe CTag)
@@ -293,7 +293,7 @@ findTagShadow ide  = readAttrCCT $ \ac -> lookupDefTagCShadow ac ide
 -- the given prefix from the identifiers already in the name space
 --
 -- * if a new identifier would collides with an existing one, the new one is
---   discarded, ie, all associations that existed before the transformation
+--   discarded, i.e., all associations that existed before the transformation
 --   started are still in effect after the transformation
 --
 applyPrefixToNameSpaces        :: String -> String -> CT s ()
@@ -305,7 +305,7 @@ applyPrefixToNameSpaces prefix repprefix  =
 
 -- | get the definition of an identifier
 --
--- * the attribute must be defined, ie, a definition must be associated with
+-- * the attribute must be defined, i.e., a definition must be associated with
 --   the given identifier
 --
 getDefOf     :: Ident -> CT s CDef
@@ -807,7 +807,7 @@ lookupStructUnion ide preferTag useShadows = do
         Just tag -> extractStruct (posOf ide) tag
         Nothing  -> unknownObjErr ide
 
--- | for the given identifier, check for the existance of both a type definition
+-- | for the given identifier, check for the existence of both a type definition
 -- or a struct, union, or enum definition
 --
 -- * if a typedef and a tag exists, the typedef takes precedence
@@ -850,9 +850,9 @@ lookupDeclOrTag ide useShadows  = do
 -- * if `ind = True', the alias may be via an indirection
 --
 -- * if `ind = True' and the alias is _not_ over an indirection, yield `True';
---   otherwise `False' (ie, the ability to hop over an indirection is consumed)
+--   otherwise `False' (i.e., the ability to hop over an indirection is consumed)
 --
--- * this may be an anonymous declaration, ie, the name in `CVarDeclr' may be
+-- * this may be an anonymous declaration, i.e., the name in `CVarDeclr' may be
 --   omitted or there may be no declarator at all
 --
 extractAlias :: CDecl -> Bool -> Maybe (Ident, Bool)

--- a/src/C2HS/CHS.hs
+++ b/src/C2HS/CHS.hs
@@ -35,9 +35,9 @@
 --
 --  where <version> is the three component version number `Version.version'.
 --  C->Haskell will only accept files whose version number match its own in
---  the first two components (ie, major and minor version).  In other words,
+--  the first two components (i.e., major and minor version).  In other words,
 --  it must be guaranteed that the format of .chi files is not altered between
---  versions that differ only in their patchlevel.  All remaining lines of the
+--  versions that differ only in their patch level.  All remaining lines of the
 --  file are version dependent and contain a dump of state information that
 --  the binding file generator needs to rescue across modules.
 --
@@ -1049,7 +1049,7 @@ parseImport hkpos pos toks = do
   return $ CHSHook (CHSImport qual modid chi pos) hkpos : frags
 
 -- | Qualified module names do not get lexed as a single token so we need to
--- reconstruct it from a sequence of identifer and dot tokens.
+-- reconstruct it from a sequence of identifier and dot tokens.
 --
 rebuildModuleId :: Ident -> [CHSToken] -> (Ident, [CHSToken])
 rebuildModuleId ide (CHSTokDot _ : CHSTokIdent _ ide' : toks) =

--- a/src/C2HS/CHS/Lexer.hs
+++ b/src/C2HS/CHS/Lexer.hs
@@ -112,8 +112,8 @@
 --    output file verbatim.
 --
 --  * In the binding-hook lexer, the lexeme `#}' transfers control back to the
---    base lexer.  An occurence of the lexeme `{#' inside the binding-hook
---    lexer triggers an error.  The symbol `{#' is not explcitly represented
+--    base lexer.  An occurrence of the lexeme `{#' inside the binding-hook
+--    lexer triggers an error.  The symbol `{#' is not explicitly represented
 --    in the resulting token stream.  However, the occurrence of a token
 --    representing one of the reserved identifiers `call', `context', `enum',
 --    and `field' marks the start of a binding hook.  Strictly speaking, `#}'
@@ -123,7 +123,7 @@
 --    representing `#}'.
 --
 --  * The rule `ident' describes Haskell identifiers, but without
---    distinguishing between variable and constructor identifers (ie, those
+--    distinguishing between variable and constructor identifiers (i.e., those
 --    starting with a lowercase and those starting with an uppercase letter).
 --    However, we use it also to scan C identifiers; although, strictly
 --    speaking, it is too general for them.  In the case of C identifiers,
@@ -162,7 +162,7 @@
 --- TODO ----------------------------------------------------------------------
 --
 --  * In `haskell', the case of a single `"' (without a matching second one)
---    is caught by an eplicit error raising rule.  This shouldn't be
+--    is caught by an explicit error raising rule.  This shouldn't be
 --    necessary, but for some strange reason, the lexer otherwise hangs when a
 --    single `"' appears in the input.
 --

--- a/src/C2HS/Config.hs
+++ b/src/C2HS/Config.hs
@@ -107,7 +107,7 @@ defaultPlatformSpec = PlatformSpec {
                         bitfieldAlignmentPS = bitfieldAlignment
                       }
 
--- | The set of platform specification that may be choosen for cross compiling
+-- | The set of platform specification that may be chosen for cross compiling
 -- bindings.
 --
 platformSpecDB :: [PlatformSpec]

--- a/src/C2HS/Gen/Bind.hs
+++ b/src/C2HS/Gen/Bind.hs
@@ -23,7 +23,7 @@
 --
 --  * If there is an error in one binding hook, it is skipped and the next one
 --    is processed (to collect as many errors as possible).  However, if at
---    least one error occured, the expansion of binding hooks ends in a fatal
+--    least one error occurred, the expansion of binding hooks ends in a fatal
 --    exception.
 --
 --  * `CST' exceptions are used to back off a binding hook as soon as an error
@@ -32,7 +32,7 @@
 --  Mapping of C types to Haskell FFI types:
 --  ----------------------------------------
 --
---  The following defines the mapping for basic types.  If the type specifer
+--  The following defines the mapping for basic types.  If the type specifier
 --  is missing, it is taken to be `int'.  In the following, elements enclosed
 --  in square brackets are optional.
 --
@@ -57,9 +57,9 @@
 --    struct ...                -> ** error **
 --    union ...                 -> ** error **
 --
---  Plain structures or unions (ie, if not the base type of a pointer type)
+--  Plain structures or unions (i.e., if not the base type of a pointer type)
 --  are not supported at the moment (the underlying FFI does not support them
---  directly).  Named types (ie, in C type names defined using `typedef') are
+--  directly).  Named types (i.e, in C type names defined using `typedef') are
 --  traced back to their original definitions.  Pointer types are mapped
 --  to `Ptr a' or `FunPtr a' depending on whether they point to a functional.
 --  Values obtained from bit fields are represented by `CInt' or `CUInt'
@@ -987,7 +987,7 @@ apathNewtypeName path = do
 --   constants is explicitly assigned a value in its definition
 --
 -- * the translation function strips prefixes where possible (different
---   enumerators maye have different prefixes)
+--   enumerators may have different prefixes)
 --
 enumDef :: CEnum -> String -> TransFun -> Bool -> [String] -> Position
         -> GB String
@@ -1485,7 +1485,7 @@ addDftMarshaller pos parms parm extTy varExTys = do
 -- * each element in the index path specifies dereferencing an address and the
 --   offset to be added to the address before dereferencing
 --
--- * the returned declaration is already normalised (ie, alias have been
+-- * the returned declaration is already normalised (i.e., alias have been
 --   expanded)
 --
 -- * it may appear as if `t.m' and `t->m' should have different access paths,
@@ -1544,7 +1544,7 @@ accessPath (CHSDeref path _pos) =                        --  *a
       return $ CDeclr oid derived' asm ats n
     derefDeclr (CDeclr _oid _unexp_deriv _ _ n) = ptrExpectedErr (posOf n)
 
--- | replaces a decleration by its alias if any
+-- | replaces a declaration by its alias if any
 --
 -- * the alias inherits any field size specification that the original
 --   declaration may have

--- a/src/C2HS/Gen/Monad.hs
+++ b/src/C2HS/Gen/Monad.hs
@@ -200,7 +200,7 @@ transTabToTransFun prefx rprefx (CHSTrans _2Case chgCase table omits) =
 --   the second string is for function results; this distinction is necessary
 --   as 'ForeignPtr's cannot be returned by a foreign function; the
 --   restriction on function result types is only for the actual result, not
---   for type arguments to parameterised pointer types, i.e., it holds for @res@
+--   for type arguments to parametrised pointer types, i.e., it holds for @res@
 --   in `Int -> IO res', but not in `Int -> Ptr res'
 --
 type PointerMap = Map (Bool, Ident) (String, String)

--- a/src/C2HS/Gen/Monad.hs
+++ b/src/C2HS/Gen/Monad.hs
@@ -200,7 +200,7 @@ transTabToTransFun prefx rprefx (CHSTrans _2Case chgCase table omits) =
 --   the second string is for function results; this distinction is necessary
 --   as 'ForeignPtr's cannot be returned by a foreign function; the
 --   restriction on function result types is only for the actual result, not
---   for type arguments to parametrised pointer types, ie, it holds for @res@
+--   for type arguments to parameterised pointer types, i.e., it holds for @res@
 --   in `Int -> IO res', but not in `Int -> Ptr res'
 --
 type PointerMap = Map (Bool, Ident) (String, String)
@@ -293,7 +293,7 @@ instance Read Ident where
 --
 -- (1) the dynamic library specified by the context hook,
 -- (2) the prefix specified by the context hook,
--- (3) the set of delayed code fragaments, ie, pieces of Haskell code that,
+-- (3) the set of delayed code fragments, i.e., pieces of Haskell code that,
 --     finally, have to be appended at the CHS module together with the hook
 --     that created them (the latter allows avoid duplication of foreign
 --     export declarations), and
@@ -363,7 +363,7 @@ getReplacementPrefix  = readCT repprefix
 --
 -- * currently only code belonging to call hooks can be delayed
 --
--- * if code for the same call hook (ie, same C function) is delayed
+-- * if code for the same call hook (i.e., same C function) is delayed
 --   repeatedly only the first entry is stored; it is checked that the hooks
 --   specify the same flags (ie, produce the same delayed code)
 --
@@ -470,7 +470,7 @@ queryPointer hsName  = do
 
 -- | merge the pointer and Haskell object maps
 --
--- * currently, the read map overrides any entires for shared keys in the map
+-- * currently, the read map overrides any entries for shared keys in the map
 --   that is already in the monad; this is so that, if multiple import hooks
 --   add entries for shared keys, the textually latest prevails; any local
 --   entries are entered after all import hooks anyway

--- a/src/Control/State.hs
+++ b/src/Control/State.hs
@@ -135,7 +135,7 @@ fatal  = CST . StateTrans.fatal
 -- message
 --
 -- * the state observed by the exception handler is *modified* by the failed
---   state transformer upto the point where the exception was thrown (this
+--   state transformer up to the point where the exception was thrown (this
 --   semantics is the only reasonable when it should be possible to use
 --   updating for maintaining the state)
 --

--- a/src/Control/StateBase.hs
+++ b/src/Control/StateBase.hs
@@ -25,7 +25,7 @@
 --  language: Haskell 98
 --
 --  * The monad `PreCST' is an instance of `STB' where the base state is fixed.
---    However, the base state itself is parameterised by an extra state
+--    However, the base state itself is parametrised by an extra state
 --    component that can be instantiated by the compiler that uses the toolkit
 --    (to store information like compiler switches) -- this is the reason for
 --    adding the prefix `Pre'.

--- a/src/Control/StateBase.hs
+++ b/src/Control/StateBase.hs
@@ -25,7 +25,7 @@
 --  language: Haskell 98
 --
 --  * The monad `PreCST' is an instance of `STB' where the base state is fixed.
---    However, the base state itself is parametrized by an extra state
+--    However, the base state itself is parameterised by an extra state
 --    component that can be instantiated by the compiler that uses the toolkit
 --    (to store information like compiler switches) -- this is the reason for
 --    adding the prefix `Pre'.

--- a/src/Control/StateTrans.hs
+++ b/src/Control/StateTrans.hs
@@ -40,7 +40,7 @@
 --    Duponcheel (Report YALEU/DCS/RR-1004) from 1993, Section 8.
 --
 --  * The use of GHC's inplace-update goodies within monads of kind `STB' is
---    possible, bacause `IO' is based on `ST' in the GHC.
+--    possible, because `IO' is based on `ST' in the GHC.
 --
 --  * In the following, we call the two kinds of state managed by the `STB' the
 --    base state (the omnipresent state of the compiler) and generic state.
@@ -232,8 +232,8 @@ interleave m gs' = STB $ let
 --
 --   - exceptions are meant to be caught in order to recover the currently
 --     executed operation; they turn into fatal errors if they are not caught;
---     execeptions are tagged, which allows to deal with multiple kinds of
---     execeptions at the same time and to handle them differently
+--     exceptions are tagged, which allows to deal with multiple kinds of
+--     exceptions at the same time and to handle them differently
 --   - user-defined fatal errors abort the currently executed operation, but
 --     they may be caught at the top-level in order to terminate gracefully or
 --     to invoke another operation; there is no special support for different
@@ -261,7 +261,7 @@ fatal s  = liftIO (ioError (userError s))
 -- message
 --
 -- * the base and generic state observed by the exception handler is *modified*
---   by the failed state transformer upto the point where the exception was
+--   by the failed state transformer up to the point where the exception was
 --   thrown (this semantics is the only reasonable when it should be possible
 --   to use updating for maintaining the state)
 --

--- a/src/Data/Attributes.hs
+++ b/src/Data/Attributes.hs
@@ -341,12 +341,12 @@ getStdAttrDft atab at dft  =
     UndefStdAttr    -> interr $ "Attributes.getStdAttrDft: Undefined in\n"
                                 ++ errLoc atab (posOf at)
 
--- | check if the attribue value is marked as "don't care"
+-- | check if the attribute value is marked as "don't care"
 --
 isDontCareStdAttr         :: AttrTable (StdAttr a) -> NodeInfo -> Bool
 isDontCareStdAttr atab at  = isDontCare (getAttr atab at)
 
--- | check if the attribue value is still undefined
+-- | check if the attribute value is still undefined
 --
 -- * we also regard "don't care" attributes as undefined
 --

--- a/src/Data/NameSpaces.hs
+++ b/src/Data/NameSpaces.hs
@@ -28,7 +28,7 @@
 --  * Each name space is organized in a hierarchical way using the notion of
 --    ranges. A name space, at any moment, always has a global range and may
 --    have several local ranges. Definitions in inner ranges hide definitions
---    of the same identifiert in outer ranges.
+--    of the same identifier in outer ranges.
 --
 --- TODO ----------------------------------------------------------------------
 --
@@ -53,7 +53,7 @@ import Data.Errors     (interr)
 --   they are not very many and the definitions entered last are the most
 --   frequently accessed ones; the list structure naturally hides older
 --   definitions, i.e., definitions from outer ranges; adding new definitions
---   is done in time proportinal to the current size of the range; removing a
+--   is done in time proportional to the current size of the range; removing a
 --   range is done in constant time (and the definitions of a range can be
 --   returned as a result of leaving the range); lookup is proportional to the
 --   number of definitions in the local ranges and the logarithm of the number
@@ -73,9 +73,9 @@ nameSpace  = NameSpace Map.empty []
 
 -- | add global definition
 --
--- * returns the modfied name space
+-- * returns the modified name space
 --
--- * if the identfier is already declared, the resulting name space contains
+-- * if the identifier is already declared, the resulting name space contains
 --   the new binding and the second component of the result contains the
 --   definition declared previously (which is henceforth not contained in the
 --   name space anymore)
@@ -99,11 +99,11 @@ leaveRange (NameSpace gs (ls:lss))  = (NameSpace gs lss, ls)
 
 -- | add local definition
 --
--- * returns the modfied name space
+-- * returns the modified name space
 --
 -- * if there is no local range, the definition is entered globally
 --
--- * if the identfier is already declared, the resulting name space contains
+-- * if the identifier is already declared, the resulting name space contains
 --   the new binding and the second component of the result contains the
 --   definition declared previously (which is henceforth not contained in the
 --   name space anymore)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -45,13 +45,13 @@
 --  --cppopts=CPPOPTS
 --        Pass the additional options CPPOPTS to the C preprocessor.
 --
---        Repeated occurences accumulate.
+--        Repeated occurrences accumulate.
 --
 --  -c CPP
 --  --cpp=CPP
 --        Use the executable CPP to invoke CPP.
 --
---        In the case of repeated occurences, the last takes effect.
+--        In the case of repeated occurrences, the last takes effect.
 --
 --  -d TYPE
 --  --dump=TYPE

--- a/src/Text/Lexers.hs
+++ b/src/Text/Lexers.hs
@@ -89,7 +89,7 @@
 --
 --  * in (>||<) in the last case, `(addBoundsNum bn bn')' is too simple, as
 --    the number of outgoing edges is not the sum of the numbers of the
---    individual states when there are conflicting edges, ie, ones labeled
+--    individual states when there are conflicting edges, i.e., ones labeled
 --    with the same character; however, the number is only used to decide a
 --    heuristic, so it is questionable whether it is worth spending the
 --    additional effort of computing the accurate number
@@ -102,7 +102,7 @@
 --    Regarding the character ranges, there seem to be at least two
 --    possibilities.  Doaitse explicitly uses ranges and avoids expanding
 --    them.  The problem with this approach is that we may only have
---    predicates such as `isAlphaNum' to determine whether a givne character
+--    predicates such as `isAlphaNum' to determine whether a given character
 --    belongs to some character class.  From this representation it is
 --    difficult to efficiently compute a range.  The second approach, as
 --    proposed by Tom Pledger <Tom.Pledger@peace.com> (on the Haskell list)
@@ -378,7 +378,7 @@ star :: Regexp s t -> Regexp s t -> Regexp s t
 --
 --   star re1 re2 = let self = (re1 +> self >|< epsilon) in self +> re2
 --
--- However, in the above, `self' is of type `Regexp s t' (ie, a functional),
+-- However, in the above, `self' is of type `Regexp s t' (i.e., a functional),
 -- whereas below it is of type `Lexer s t'.  Thus, below we have a graphical
 -- body (finite representation of an infinite structure), which doesn't grow
 -- with the size of the accepted lexeme - in contrast to the definition using


### PR DESCRIPTION
ChangeLog.old
TODO.CTKlight
examples/libghttpHS/Ghttp.chs
src/C2HS/C.hs
src/C2HS/C/Attrs.hs
src/C2HS/C/Names.hs
src/C2HS/C/Trav.hs
src/C2HS/CHS.hs
src/C2HS/CHS/Lexer.hs
src/C2HS/Config.hs
src/C2HS/Gen/Bind.hs
src/C2HS/Gen/Monad.hs
src/Control/State.hs
src/Control/StateBase.hs
src/Control/StateTrans.hs
src/Data/Attributes.hs
src/Data/NameSpaces.hs
src/Main.hs
src/Text/Lexers.hs
