### PR TITLE
use ghc-paths to support cross-compiling

### DIFF
--- a/c2hs.cabal
+++ b/c2hs.cabal
@@ -131,7 +131,8 @@ Executable c2hs
                     bytestring,
                     language-c >= 0.7.1 && < 0.10,
                     filepath,
-                    dlist
+                    dlist,
+                    ghc-paths
 
     if flag(base3)
         Build-Depends: base >= 3, process, directory, array, containers, pretty

--- a/src/C2HS/Gen/Bind.hs
+++ b/src/C2HS/Gen/Bind.hs
@@ -134,6 +134,7 @@ import qualified Foreign.Storable as Storable (Storable(alignment),
                                                Storable(sizeOf))
 import Foreign    (Ptr, FunPtr)
 import Foreign.C
+import GHC.Paths (ghc)
 
 -- Language.C / compiler toolkit
 import Language.C.Data.Position
@@ -3136,7 +3137,7 @@ cCompiler = unsafePerformIO $ do
   case mcc of
     Just cc -> return cc
     Nothing -> do
-      (code, stdout, _) <- readProcessWithExitCode "ghc" ["--info"] ""
+      (code, stdout, _) <- readProcessWithExitCode ghc ["--info"] ""
       when (code /= ExitSuccess) $
         error "Failed to determine C compiler from 'ghc --info'!"
       let vals = read stdout :: [(String, String)]


### PR DESCRIPTION
Use `ghc-paths` in `c2hs` executable to support cross-compiling where `ghc`'s executable name is prefixed, for eg. `x86_64-unknown-linux-musl-ghc`.

Otherwise this error is raised:
> c2hs: does not exist (file: `Uncaught fatal error: ghc: readCreateProcessWithExitCode: posix_spawnp: does not exist (No such file or directory)