### PR TITLE
Increase language-c upper bound from 0.10 to 0.11

### DIFF
--- a/c2hs.cabal
+++ b/c2hs.cabal
@@ -129,7 +129,7 @@ flag base3
 Executable c2hs
     Build-Depends:  base >= 2 && < 5,
                     bytestring,
-                    language-c >= 0.7.1 && < 0.10,
+                    language-c >= 0.7.1 && < 0.11,
                     filepath,
                     dlist
 


### PR DESCRIPTION
This increases the `language-c` upper bound from < 0.10 to < 0.11. `c2hs` has been shown to be working with the new language-c 0.10.0.

See:
* https://github.com/visq/language-c/pull/100
* https://github.com/visq/language-c/issues/98